### PR TITLE
Prompt the user to source ~/.bashrc after setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,7 @@ if [ "$(grep "FLITSR_HOME" ~/.bashrc)" == "" ]; then
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   echo "export FLITSR_HOME=\"$SCRIPT_DIR\"" >> ~/.bashrc
   echo "export PATH=\"\$FLITSR_HOME/bin:\$PATH\"" >> ~/.bashrc
+  echo "~/.bashrc has been updated. Run 'source ~/.bashrc' to update your session."
 fi
 # install numpy
 pip install numpy


### PR DESCRIPTION
This adds a message to the setup script that prompts the user to source their .bashrc file if it has been updated. This ensures the FLITSR executable is available in the current session. 