### PR TITLE
Use virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/bin/flitsr
+++ b/bin/flitsr
@@ -1,2 +1,4 @@
 #!/bin/bash
-python3 $FLITSR_HOME/flitsr "$@"
+source "$FLITSR_HOME/.venv/bin/activate"
+python $FLITSR_HOME/flitsr "$@"
+deactivate

--- a/bin/merge
+++ b/bin/merge
@@ -1,2 +1,4 @@
 #!/bin/bash
-python3 $FLITSR_HOME/flitsr/merge.py "$@"
+source "$FLITSR_HOME/.venv/bin/activate"
+python $FLITSR_HOME/flitsr/merge.py "$@"
+deactivate

--- a/bin/percent_at_n
+++ b/bin/percent_at_n
@@ -1,2 +1,4 @@
 #!/bin/bash
-python3 $FLITSR_HOME/flitsr/percent_at_n.py "$@"
+source "$FLITSR_HOME/.venv/bin/activate"
+python $FLITSR_HOME/flitsr/percent_at_n.py "$@"
+deactivate

--- a/bin/plot
+++ b/bin/plot
@@ -1,2 +1,4 @@
 #!/bin/bash
-python3 $FLITSR_HOME/flitsr/plot.py "$@"
+source "$FLITSR_HOME/.venv/bin/activate"
+python $FLITSR_HOME/flitsr/plot.py "$@"
+deactivate

--- a/bin/reduce
+++ b/bin/reduce
@@ -1,2 +1,4 @@
 #!/bin/bash
-python3 $FLITSR_HOME/flitsr/reduce.py "$@"
+source "$FLITSR_HOME/.venv/bin/activate"
+python $FLITSR_HOME/flitsr/reduce.py "$@"
+deactivate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+iniconfig==2.0.0
+numpy==1.26.4
+packaging==24.0
+pluggy==1.4.0
+pytest==8.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 iniconfig==2.0.0
-numpy==1.26.4
+numpy==1.24.4
 packaging==24.0
 pluggy==1.4.0
 pytest==8.1.1

--- a/setup.sh
+++ b/setup.sh
@@ -7,8 +7,12 @@ fi
 # add the script path to the bashrc
 if [ "$(grep "FLITSR_HOME" ~/.bashrc)" == "" ]; then
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+  export FLITSR_HOME="$SCRIPT_DIR"
   echo "export FLITSR_HOME=\"$SCRIPT_DIR\"" >> ~/.bashrc
   echo "export PATH=\"\$FLITSR_HOME/bin:\$PATH\"" >> ~/.bashrc
 fi
 # install numpy
-pip install numpy
+python -m venv "$FLITSR_HOME/.venv"
+source "$FLITSR_HOME/.venv/bin/activate"
+pip install -r "$FLITSR_HOME/requirements.txt"
+deactivate


### PR DESCRIPTION
This modifies the FLITSR setup script and executables to use a Python virtual environment, preventing version conflicts with global packages, reducing the installation footprint and avoiding issues with the naming of the python executable. It also adds a .gitignore and a requirements.txt file (which includes a previously unspecified dependency: pytest).