### PR TITLE
Spectrum overhaul

### DIFF
--- a/flitsr/artemis_wrapper.py
+++ b/flitsr/artemis_wrapper.py
@@ -9,7 +9,7 @@ def run_artemis(spectrum: Spectrum, metric: str, numUniverse=17,
     # Set default metric
     if (metric == 'artemis'):
         metric = 'ochiai'
-    elements = spectrum.elements()
+    elements = spectrum.groups()
     matrix, errVector = spectrum.to_matrix()
     rankingList = artemis.explorer(matrix, errVector, spectrum.locs(),
                                    metric, numUniverse, maxUniverse, p)

--- a/flitsr/cutoff_points.py
+++ b/flitsr/cutoff_points.py
@@ -56,24 +56,24 @@ def mba_zombie(spectrum: Spectrum, faults: Dict[int, List[Spectrum.Element]],
 def mba_5_perc(spectrum: Spectrum, faults: Dict[int, List[Spectrum.Element]],
                scores: Scores, formula: str, effort: str):
     size = 0
-    for group in spectrum.groups:
-        size += len(group)
+    for group in spectrum.groups():
+        size += len(group.get_elements())
     return method(int(size*0.05), spectrum, faults, scores, effort, True)
 
 
 def mba_10_perc(spectrum: Spectrum, faults: Dict[int, List[Spectrum.Element]],
                 scores: Scores, formula: str, effort: str):
     size = 0
-    for group in spectrum.groups:
-        size += len(group)
+    for group in spectrum.groups():
+        size += len(group.get_elements())
     return method(int(size*0.1), spectrum, faults, scores, effort, True)
 
 
 def mba_const_add(spectrum: Spectrum, faults: Dict[int, List[Spectrum.Element]],
                   scores: Scores, formula: str, effort: str):
     tot_size = 0
-    for group in spectrum.groups:
-        tot_size += len(group)
+    for group in spectrum.groups():
+        tot_size += len(group.get_elements())
     sus = Suspicious(0, spectrum.tf, 0, spectrum.tp)
     zero = sus.execute(formula)
     new_scores = Scores()
@@ -91,7 +91,7 @@ def mba_const_add(spectrum: Spectrum, faults: Dict[int, List[Spectrum.Element]],
                     faults.values())):
                 fault_num += 1
             new_scores.extend([next_score])
-            size += len(spectrum.get_group(next_score.elem))
+            size += len(next_score.group.get_elements())
             next_score = next(s_iter, None)
         if (fault_num != 0):  # should've stopped already: size <= stop_i
             # recalculate stop amount
@@ -120,7 +120,7 @@ def mba_optimal(spectrum: Spectrum, faults: Dict[int, List[Spectrum.Element]],
                     faults.values())):
                 fault_num += 1
             new_scores.extend([next_score])
-            size += len(spectrum.get_group(next_score.elem))
+            size += len(next_score.group.get_elements())
             next_score = next(s_iter, None)
         if (fault_num != 0):  # should've stopped already: size <= stop_i
             # recalculate stop amount
@@ -170,7 +170,7 @@ def method(stop_score: float, spectrum: Spectrum,
                                           fault_locs in faults.values())):
                 first_fault = len(temp_scores)
             temp_scores.append(next_score)
-            size += len(spectrum.get_group(next_score.elem))
+            size += len(next_score.group.get_elements())
             next_score = next(s_iter, None)
         if (effort == 'worst' or score.score > stop_score or first_fault == -1):
             new_scores.extend(temp_scores)

--- a/flitsr/flitsr.py
+++ b/flitsr/flitsr.py
@@ -98,8 +98,8 @@ def flitsr_ordering(spectrum: Spectrum, basis: List[Spectrum.Group],
     confs = []
     # check if internal ranking order needs to be determined
     if (flitsr_order in ['auto', 'conf']):
-        for elem in basis:
-            ts = list(spectrum.get_tests(elem, only_failing=True))
+        for group in basis:
+            ts = list(spectrum.get_tests(group, only_failing=True))
             possibles: Set[Spectrum.Group] = set()
             possibles.update(spectrum.get_executed_groups(ts[0]))
             for test in ts[1:]:
@@ -116,9 +116,9 @@ def flitsr_ordering(spectrum: Spectrum, basis: List[Spectrum.Group],
         big, small = [], []
         for group in basis:
             if (len(group.get_elements()) > 5):
-                big.append(elem)
+                big.append(group)
             else:
-                small.append(elem)
+                small.append(group)
         if (len(big) != 0 and len(small) != 0):
             return flitsr_ordering(spectrum, small, sort, flitsr_order) + \
                 flitsr_ordering(spectrum, big, sort, flitsr_order)

--- a/flitsr/flitsr.py
+++ b/flitsr/flitsr.py
@@ -23,7 +23,7 @@ from flitsr.artemis_wrapper import run_artemis
 
 def remove_faulty_elements(spectrum: Spectrum,
                            tests_removed: Set[Spectrum.Test],
-                           faulty: List[Spectrum.Element]):
+                           faulty: List[Spectrum.Group]):
     """Removes all tests that execute an 'actually' faulty element"""
     toRemove = []
     for test in tests_removed:
@@ -34,7 +34,7 @@ def remove_faulty_elements(spectrum: Spectrum,
     tests_removed.difference_update(toRemove)
 
 
-def multiRemove(spectrum: Spectrum, faulty: List[Spectrum.Element]) -> bool:
+def multiRemove(spectrum: Spectrum, faulty: List[Spectrum.Group]) -> bool:
     """
     Remove the elements given by faulty from the spectrum, and remove any test
     cases executing these elements only.
@@ -46,13 +46,13 @@ def multiRemove(spectrum: Spectrum, faulty: List[Spectrum.Element]) -> bool:
         executing.update(exe)
 
     # Remove all elements in faulty set
-    for elem in faulty:
-        spectrum.remove_element(elem)
+    for group in faulty:
+        spectrum.remove_group(group)
 
     multiFault = False
     for test in executing:
-        for elem in spectrum.elements():  # remaining elements not in faulty
-            if (spectrum[test][elem]):
+        for group in spectrum.groups():  # remaining groups not in faulty
+            if (spectrum[test][group]):
                 break
         else:
             multiFault = True
@@ -62,7 +62,7 @@ def multiRemove(spectrum: Spectrum, faulty: List[Spectrum.Element]) -> bool:
 
 def flitsr(spectrum: Spectrum, formula: str,
            advanced_type: AdvancedType = AdvancedType.FLITSR,
-           tiebrk=3) -> List[Spectrum.Element]:
+           tiebrk=3) -> List[Spectrum.Group]:
     """Executes the recursive flitsr algorithm to identify faulty elements"""
     if (spectrum.tf == 0):
         return []
@@ -71,8 +71,8 @@ def flitsr(spectrum: Spectrum, formula: str,
     else:
         sort = Suspicious.apply_formula(spectrum, formula, tiebrk)
     s_iter = iter(sort)
-    element = next(s_iter).elem
-    tests_removed = spectrum.get_tests(element, only_failing=True, remove=True)
+    group = next(s_iter).group
+    tests_removed = spectrum.get_tests(group, only_failing=True, remove=True)
     while (len(tests_removed) == 0):  # sanity check
         if ((s2 := next(s_iter, None)) is None):
             count_non_removed = len(spectrum.failing())
@@ -81,18 +81,18 @@ def flitsr(spectrum: Spectrum, formula: str,
                   file=sys.stderr)
             return []
         # continue trying the next element if available
-        element = s2.elem
-        tests_removed = spectrum.get_tests(element, only_failing=True, remove=True)
+        group = s2.group
+        tests_removed = spectrum.get_tests(group, only_failing=True, remove=True)
     faulty = flitsr(spectrum, formula, advanced_type, tiebrk)
     remove_faulty_elements(spectrum, tests_removed, faulty)
     if (len(tests_removed) > 0):
-        faulty.append(element)
+        faulty.append(group)
     return faulty
 
 
-def flitsr_ordering(spectrum: Spectrum, basis: List[Spectrum.Element],
+def flitsr_ordering(spectrum: Spectrum, basis: List[Spectrum.Group],
                     sort: score.Scores,
-                    flitsr_order='auto') -> List[Spectrum.Element]:
+                    flitsr_order='auto') -> List[Spectrum.Group]:
     if (len(basis) == 0):
         return basis
     confs = []
@@ -100,10 +100,10 @@ def flitsr_ordering(spectrum: Spectrum, basis: List[Spectrum.Element],
     if (flitsr_order in ['auto', 'conf']):
         for elem in basis:
             ts = list(spectrum.get_tests(elem, only_failing=True))
-            possibles: Set[Spectrum.Element] = set()
-            possibles.update(spectrum.get_executed_elements(ts[0]))
+            possibles: Set[Spectrum.Group] = set()
+            possibles.update(spectrum.get_executed_groups(ts[0]))
             for test in ts[1:]:
-                possibles.intersection_update(spectrum.get_executed_elements(test))
+                possibles.intersection_update(spectrum.get_executed_groups(test))
             confs.append(len(possibles))
     if (flitsr_order == 'auto'):
         if (all(c > 3 for c in confs)):
@@ -114,8 +114,8 @@ def flitsr_ordering(spectrum: Spectrum, basis: List[Spectrum.Element],
             flitsr_order = 'conf'
         # check for big groups
         big, small = [], []
-        for elem in basis:
-            if (len(spectrum.get_group(elem)) > 5):
+        for group in basis:
+            if (len(group.get_elements()) > 5):
                 big.append(elem)
             else:
                 small.append(elem)
@@ -157,8 +157,8 @@ def run(spectrum: Spectrum, formula: str, advanced_type: AdvancedType,
                 ordered_basis = flitsr_ordering(spectrum, basis, sort,
                                                 flitsr_order)
                 for x in sort:
-                    if (x.elem in basis):
-                        x.score = val - ordered_basis.index(x.elem)
+                    if (x.group in basis):
+                        x.score = val - ordered_basis.index(x.group)
                 val = val-len(basis)
             # Reset the coverage matrix and counts
             newSpectrum.reset()

--- a/flitsr/output.py
+++ b/flitsr/output.py
@@ -16,8 +16,8 @@ def print_names(spectrum, scores=None, file=sys.stdout):
             print("Faulty grouping: ", "[", file=file)
         else:
             print("Faulty grouping:", score.score, "[", file=file)
-        group = spectrum.get_group(score.elem)
-        for elem in group:
+        group = score.group
+        for elem in group.get_elements():
             print(" ", elem, file=file)
         print("]", file=file)
 
@@ -39,8 +39,8 @@ def print_spectrum(spectrum: Spectrum):
 def print_csv(spectrum: Spectrum, scores: Scores, file=sys.stdout):
     print("name;suspiciousness_value", file=file)
     for score in scores:
-        group = spectrum.get_group(score.elem)
-        for elem in group:
+        group = score.group
+        for elem in group.get_elements():
             print(elem.gzoltar_str(), ';', score.score, sep='', file=file)
 
 
@@ -48,8 +48,9 @@ def print_spectrum_csv(spectrum: Spectrum, file=sys.stdout):
     ts = [str(t.name)+' ('+('PASS' if t.outcome is Outcome.PASSED else
                             'FAIL')+')' for t in spectrum.tests()]
     print('Element', *ts, sep=',', file=file)
-    for elem in spectrum._full_elements:
-        print(elem, end=',', file=file)
+    # TODO: change _elements below to elements()
+    for elem in spectrum._elements:
+        # print(elem, end=',', file=file)
         tests = ['X' if spectrum[t][elem] else '' for t in spectrum.tests()]
         print(elem, *tests, sep=',', file=file)
 
@@ -61,7 +62,8 @@ def print_tcm(spectrum: Spectrum, file=sys.stdout):
               "FAILED", file=file)
     print(file=file)
     print("#uuts", file=file)
-    for elem in spectrum._full_elements:
+    # TODO: change _elements below to elements()
+    for elem in spectrum._elements:
         print(elem.gzoltar_str(incl_faults=False),
               f" | {' | '.join([str(e) for e in elem.faults])}"
               if elem.isFaulty() else "",
@@ -70,7 +72,7 @@ def print_tcm(spectrum: Spectrum, file=sys.stdout):
     print("#matrix", file=file)
     for test in spectrum.tests():
         first = True
-        for elem_id, elem in enumerate(spectrum._full_elements):
+        for elem_id, elem in enumerate(spectrum._elements):
             if (spectrum[test][elem]):
                 print(("" if first else " ")+str(elem_id), "1", end="",
                       file=file)

--- a/flitsr/parallel.py
+++ b/flitsr/parallel.py
@@ -46,16 +46,16 @@ def partition_table(d: str, spectrum: Spectrum,
                 toRemove.add(test)
         for test in toRemove:
             new_spectrum.remove(test, hard=True)
-        trim_elements(new_spectrum)
+        trim_groups(new_spectrum)
         spectrums.append(new_spectrum)
     return spectrums
 
 
-def trim_elements(spectrum):
-    """Remove elements that are not in this block (i.e. ef = 0)"""
+def trim_groups(spectrum):
+    """Remove groups that are not in this block (i.e. ef = 0)"""
     toRemove = set()
-    for elem in spectrum.elements():
-        if (spectrum.f[elem] == 0):
-            toRemove.add(elem)
-    for elem in toRemove:
-        spectrum.remove_element(elem)
+    for group in spectrum.groups():
+        if (spectrum.f[group] == 0):
+            toRemove.add(group)
+    for group in toRemove:
+        spectrum.remove_group(group)

--- a/flitsr/percent_at_n.py
+++ b/flitsr/percent_at_n.py
@@ -19,10 +19,10 @@ def getBumps(ties: Ties, spectrum: Spectrum, worst_effort=False,
     total = 0
     size = 0
     if (collapse):
-        size = len(spectrum.groups)
+        size = len(spectrum.groups())
     else:
-        for group in spectrum.groups:
-            size += len(group)
+        for group in spectrum.groups():
+            size += len(group.get_elements())
     bumps = [float(size)]
     try:
         while (True):

--- a/flitsr/precision_recall.py
+++ b/flitsr/precision_recall.py
@@ -25,10 +25,10 @@ def method(n: Any, ties: Ties, spectrum: Spectrum, perc: bool,
            worst_effort: bool, collapse: bool) -> Tuple[float, int]:
     size = 0
     if (collapse):
-        size = len(spectrum.groups)
+        size = len(spectrum.groups())
     else:
-        for group in spectrum.groups:
-            size += len(group)
+        for group in spectrum.groups():
+            size += len(group.get_elements())
     if (n == "b"):
         n = -1
     elif (n == "f"):

--- a/flitsr/ranking.py
+++ b/flitsr/ranking.py
@@ -1,8 +1,34 @@
 import re
-from typing import Tuple, List, Union
+from typing import Tuple, List, Union, Any
 from flitsr.spectrum import Spectrum
 from flitsr.spectrumBuilder import SpectrumBuilder
 from flitsr.score import Scores
+
+
+class RankingSpectrumBuilder:
+    def __init__(self):
+        self._elements: List[Spectrum.Element] = []
+        self._groups: List[Spectrum.Group] = []
+
+    def addElement(self, details: List[str],
+                   faults: List[Any]) -> Spectrum.Element:
+        e = Spectrum.Element(details, len(self._elements), faults)
+        self._elements.append(e)
+        return e
+
+    def createGroup(self, elems: List[Spectrum.Element]) -> Spectrum.Group:
+        """
+        Hard-code the groups for a pre-determined spectrum
+        """
+        i = len(self._groups)
+        g = Spectrum.Group(elems, i)
+        self._groups.append(g)
+        for e in elems:
+            e.set_group(g)
+        return g
+
+    def get_spectrum(self):
+        return Spectrum(self._elements, self._groups, [], {})
 
 
 def read_any_ranking(ranking_file: str,
@@ -17,7 +43,7 @@ def read_any_ranking(ranking_file: str,
 def read_ranking(ranking_file: str,
                  method_level=False) -> Tuple[Scores, Spectrum]:
     f = open(ranking_file)
-    spectrumBuilder = SpectrumBuilder()
+    spectrumBuilder = RankingSpectrumBuilder()
     scores = Scores()
     i = 0  # number of actual lines
     bugs = 0
@@ -48,6 +74,7 @@ def read_ranking(ranking_file: str,
             if ((details[0], details[1]) not in methods):
                 # add with first line number
                 elem = spectrumBuilder.addElement(details, faults)
+                spectrumBuilder.createGroup([elem])
                 methods[(details[0], details[1])] = elem
                 method_map[i] = elem
             else:
@@ -57,30 +84,29 @@ def read_ranking(ranking_file: str,
                         elem.faults.append(fault)
             # Add/Update the method's score
             elem = method_map[i]
-            score_elem = scores.get_score(elem)
-            if (score_elem is None):
-                scores.append(elem, score, 0)
-            else:
+            group = elem.group()
+            if (scores.has_group(group)):
+                score_elem = scores.get_score(group)
                 score_elem.score = max(score_elem.score, score)
+            else:
+                scores.append(group, score, 0)
         else:
             details = [r.group(1)+"."+r.group(2), r.group(3), l[1]]
-            elem = spectrum.addElement(details, faults)
+            elem = spectrumBuilder.addElement(details, faults)
+            spectrumBuilder.createGroup([elem])
             method_map[i] = elem
-            scores.append(elem, score, 0)
+            scores.append(elem.group(), score, 0)
         i += 1
-    # Hard-code the groups for a pre-determined spectrum
-    spectrum.groups = [[elem] for elem in spectrum.elements()]
-    spectrum.remove_unnecessary()
+    spectrum = spectrumBuilder.get_spectrum()
     return scores, spectrum
 
 
 def read_flitsr_ranking(ranking_file: str) -> Tuple[Scores, Spectrum]:
     f = open(ranking_file)
-    spectrum = Spectrum()
+    spectrumBuilder = RankingSpectrumBuilder()
     scores = Scores()
     num_locs = 0  # number of reported locations (methods/lines)
     i = 0  # number of actual lines
-    groups: List[List[Spectrum.Element]] = []  # manually create groups
     line = f.readline()
     while (line != ""):
         line = line.strip()
@@ -91,7 +117,7 @@ def read_flitsr_ranking(ranking_file: str) -> Tuple[Scores, Spectrum]:
         else:
             score = float(str_score)
         line = f.readline().strip()
-        groups.append([])
+        group_elems = []
         while (not line.startswith("]")):
             m = re.fullmatch("\\s*(\\S*)\\s*(?:\\(FAULT ([0-9.,]+)\\))?", line)
             if (m is None):
@@ -103,13 +129,13 @@ def read_flitsr_ranking(ranking_file: str) -> Tuple[Scores, Spectrum]:
                           for i in m.group(2).split(',')]
             else:
                 faults = []
-            elem = spectrum.addElement(details, faults)
-            groups[num_locs].append(elem)
+            elem = spectrumBuilder.addElement(details, faults)
+            group_elems.append(elem)
             i += 1
             line = f.readline().strip()
-        scores.append(groups[num_locs][0], score, 0)
+        group = spectrumBuilder.createGroup(group_elems)
+        scores.append(group, score, 0)
         num_locs += 1
         line = f.readline().strip()
-    spectrum.groups = groups  # override groups object
-    spectrum.remove_unnecessary()
+    spectrum = spectrumBuilder.get_spectrum()
     return scores, spectrum

--- a/flitsr/ranking.py
+++ b/flitsr/ranking.py
@@ -1,6 +1,7 @@
 import re
 from typing import Tuple, List, Union
 from flitsr.spectrum import Spectrum
+from flitsr.spectrumBuilder import SpectrumBuilder
 from flitsr.score import Scores
 
 
@@ -16,7 +17,7 @@ def read_any_ranking(ranking_file: str,
 def read_ranking(ranking_file: str,
                  method_level=False) -> Tuple[Scores, Spectrum]:
     f = open(ranking_file)
-    spectrum = Spectrum()
+    spectrumBuilder = SpectrumBuilder()
     scores = Scores()
     i = 0  # number of actual lines
     bugs = 0
@@ -46,7 +47,7 @@ def read_ranking(ranking_file: str,
             details = [r.group(1)+"."+r.group(2), r.group(3), l[1]]
             if ((details[0], details[1]) not in methods):
                 # add with first line number
-                elem = spectrum.addElement(details, faults)
+                elem = spectrumBuilder.addElement(details, faults)
                 methods[(details[0], details[1])] = elem
                 method_map[i] = elem
             else:

--- a/flitsr/score.py
+++ b/flitsr/score.py
@@ -7,30 +7,30 @@ import copy
 class Scores:
     class Score:
         """
-        A element from a spectrum, together with its scores.
+        A group from a spectrum, together with its scores.
         """
-        def __init__(self, elem: Spectrum.Element, score: float,
+        def __init__(self, group: Spectrum.Group, score: float,
                      exec_count: int):
-            self.elem = elem
+            self.group = group
             self.score = score
             self.exec = exec_count
 
         def __str__(self):
-            return "(" + str(self.elem) + ", " + str(self.score) + ")"
+            return "(" + str(self.group) + ", " + str(self.score) + ")"
 
         def __repr__(self):
             return str(self)
 
     def __init__(self):
         self._scores: List[Scores.Score] = []
-        self.elem_map: Dict[Spectrum.Element, Scores.Score] = {}
+        self.group_map: Dict[Spectrum.Group, Scores.Score] = {}
         self.place = 0
 
     def __getitem__(self, index: int):
         return self._scores[index]
 
-    def get_score(self, elem):
-        return self.elem_map[elem]
+    def get_score(self, group: Spectrum.Group) -> Score:
+        return self.group_map[group]
 
     def sort(self, reverse: bool, tiebrk: int):
         if (tiebrk == 1):  # Sorted by execution counts
@@ -41,9 +41,9 @@ class Scores:
             self._scores.sort(key=lambda x: x.score, reverse=reverse)
         elif (tiebrk == 3):  # original ranking tie break
             if (orig is not None):  # sort by original rank then exec count
-                self._scores.sort(key=lambda x: orig.get_score(x.elem).exec,
+                self._scores.sort(key=lambda x: orig.get_score(x.group).exec,
                                   reverse=reverse)
-                self._scores.sort(key=lambda x: orig.get_score(x.elem).score,
+                self._scores.sort(key=lambda x: orig.get_score(x.group).score,
                                   reverse=reverse)
             else:  # if no orig, still sort by current execution count
                 self._scores.sort(key=lambda x: x.exec, reverse=reverse)
@@ -51,15 +51,15 @@ class Scores:
         else:
             self._scores.sort(key=lambda x: x.score, reverse=reverse)
 
-    def append(self, elem: Spectrum.Element, score: float, exec_count: int):
-        created = Scores.Score(elem, score, exec_count)
+    def append(self, group: Spectrum.Group, score: float, exec_count: int):
+        created = Scores.Score(group, score, exec_count)
         self._scores.append(created)
-        self.elem_map[elem] = created
+        self.group_map[group] = created
 
     def extend(self, scores: List[Score]):
         self._scores.extend(scores)
         for score in scores:
-            self.elem_map[score.elem] = score
+            self.group_map[score.group] = score
 
     def __iter__(self):
         return iter(self._scores)

--- a/flitsr/score.py
+++ b/flitsr/score.py
@@ -61,6 +61,9 @@ class Scores:
         for score in scores:
             self.group_map[score.group] = score
 
+    def has_group(self, group: Spectrum.Group) -> bool:
+        return group in self.group_map
+
     def __iter__(self):
         return iter(self._scores)
 

--- a/flitsr/spectrum.py
+++ b/flitsr/spectrum.py
@@ -235,7 +235,8 @@ class Spectrum:
         self.p: Dict[Spectrum.Group, int] = dict()
         self.f: Dict[Spectrum.Group, int] = dict()
         # Initialize element related properties
-        self._groups = sorted(groups, key=lambda g: g.get_elements()[0].tup)
+        edict = {e: i for i, e in enumerate(elements)}
+        self._groups = sorted(groups, key=lambda g: edict[g.get_elements()[0]])
         for i, group in enumerate(self._groups):
             group.set_index(i)
             self.p[group] = 0

--- a/flitsr/spectrum.py
+++ b/flitsr/spectrum.py
@@ -405,9 +405,9 @@ class Spectrum:
         executed = set()
         entities: Sequence[Spectrum.Entity]
         if (groups):
-            entities = self._elements
-        else:
             entities = self._groups
+        else:
+            entities = self._elements
         for ent in entities:
             if (self[test][ent]):
                 executed.add(ent)

--- a/flitsr/spectrumBuilder.py
+++ b/flitsr/spectrumBuilder.py
@@ -1,0 +1,74 @@
+from typing import List, Dict, Any
+from flitsr.spectrum import Spectrum, Outcome
+
+
+class SpectrumBuilder:
+    def __init__(self):
+        self._elements: List[Spectrum.Element] = []
+        self._tests: List[Spectrum.Test] = []
+        self._groups: List[Spectrum.Group] = [Spectrum.Group()]
+        self._executions: Dict[Spectrum.Test, Dict[Spectrum.Element, bool]] = {}
+
+    def get_tests(self):
+        return self._tests
+
+    def addTest(self, name: str, index: int, outcome: Outcome):
+        t = Spectrum.Test(name, index, outcome)
+        self._tests.append(t)
+        return t
+
+    def addElement(self, details: List[str],
+                   faults: List[Any]) -> Spectrum.Element:
+        e = Spectrum.Element(details, len(self._elements), faults)
+        self._elements.append(e)
+        self._groups[0].append(e)
+        return e
+
+    def addExecution(self, test: Spectrum.Test, elem: Spectrum.Element,
+                     executed: bool):
+        if (test not in self._executions):
+            self._executions[test] = {}
+        self._executions[test][elem] = executed
+        # if (executed):
+        #     if (test.outcome is Outcome.PASSED):
+        #         self.p[elem] += 1
+        #     else:
+        #         self.f[elem] += 1
+
+    def split_groups_on_test(self, test: Spectrum.Test):
+        """
+        Given one test pertaining to a row in the spectrum, split the groups
+        according to the coverage. The split will potentially split each group
+        in half, based on those elements that are executed in the test, and
+        those that are not.
+        """
+        row = self._executions[test]
+        new_groups: List[Spectrum.Group] = []
+        for group in self._groups:
+            elems = group.get_elements()
+            collect: List[List[Spectrum.Element]] = [[], []]
+            for elem in elems:
+                collect[row.get(elem, False)].append(elem)
+            for c in collect:
+                if (c != []):
+                    new_groups.append(Spectrum.Group(c))
+        self._groups = new_groups
+
+    def get_spectrum(self):
+        spectrum = Spectrum(self._elements, self._groups, self._tests,
+                            self._executions)
+        return spectrum
+
+    # def remove_unnecessary(self):
+    #     """
+    #     Remove the unnecessary elements that are within the groups from the
+    #     spectrum.
+    #     """
+    #     remove = []
+    #     for group in self._groups:
+    #         remove.extend(group[1:])
+    #         self.group_dict[group[0]] = group
+    #     # remove.sort(reverse=True)
+    #     # self.locs -= len(remove)
+    #     for elem in remove:
+    #         self.remove_element(elem)

--- a/flitsr/suspicious.py
+++ b/flitsr/suspicious.py
@@ -41,7 +41,7 @@ class Suspicious():
         Assumes a non-empty spectrum.
         """
         scores: Scores = Scores()
-        for elem in spec.elements():
+        for elem in spec.groups():
             sus = Suspicious(spec.f[elem], spec.tf, spec.p[elem], spec.tp)
             exect = spec.p[elem]+spec.f[elem]
             scores.append(elem, sus.execute(formula), exect)


### PR DESCRIPTION
This is a complete overhaul of the spectrum creation and grouping components. The spectrum is now no longer created in partial states, but is created using a `SpectrumBuilder`, which constructs the spectrum all-at-once.

Because of this new design, it is now possible for the spectrum to have a separation between groups and elements (collectively called Entities) where groups are collections of elements and are the actual entries in the spectrum. Almost all operations now work with groups in the spectrum, except when the actual underlying elements are required.

The ranking input also uses a variant of the `SpectrumBuilder` called `RankingSpectrumBuilder`, which builds the elements for the spectrum based on the information in the ranking.