### PR TITLE
Backwards- and DUA-compatible FLITSR rank reading

### DIFF
--- a/flitsr/read_ranking.py
+++ b/flitsr/read_ranking.py
@@ -118,8 +118,10 @@ def read_flitsr_ranking(ranking_file: str) -> Tuple[Ranking, Spectrum]:
         line = f.readline().strip()
         group_elems = []
         while (not line.startswith("]")):
+            # read in ranked element (old or new FLITSR format)
             m = re.fullmatch("\\s*(?:\([0-9]+\)\\s*)?(\\S*)\\s*(?:\\(FAULT ([0-9.,]+)\\))?", line)
             if (m is None):
+                # if normal format fails, try DUA format
                 m = re.fullmatch("\\s*(?:\([0-9]+\)\\s*)?(\\S*\\s\\S*\\s\\S*)\\s*(?:\\(FAULT ([0-9.,]+)\\))?", line)
                 if (m is None):
                     raise ValueError("Incorrectly formatted line \"" + line +

--- a/flitsr/read_ranking.py
+++ b/flitsr/read_ranking.py
@@ -118,9 +118,11 @@ def read_flitsr_ranking(ranking_file: str) -> Tuple[Ranking, Spectrum]:
         line = f.readline().strip()
         group_elems = []
         while (not line.startswith("]")):
-            m = re.fullmatch("\\s*(\\S*)\\s*(?:\\(FAULT ([0-9.,]+)\\))?", line)
+            m = re.fullmatch("\\s*(?:\([0-9]+\)\\s*)?(\\S*)\\s*(?:\\(FAULT ([0-9.,]+)\\))?", line)
             if (m is None):
-                raise ValueError("Incorrectly formatted line \"" + line +
+                m = re.fullmatch("\\s*(?:\([0-9]+\)\\s*)?(\\S*\\s\\S*\\s\\S*)\\s*(?:\\(FAULT ([0-9.,]+)\\))?", line)
+                if (m is None):
+                    raise ValueError("Incorrectly formatted line \"" + line +
                                  "\" when reading input ranking file")
             details = m.group(1).split('|')
             if (m.group(2)):


### PR DESCRIPTION
Adjust regex for backward compatibility with numbered ranking; add check to account for DUA elements with spaces between. 

Edited file: flitsr/read_ranking.py